### PR TITLE
Fix: Undeclared identifier in call to `protojson.Marshal`

### DIFF
--- a/cmd/protoc-gen-event/event.go
+++ b/cmd/protoc-gen-event/event.go
@@ -77,7 +77,7 @@ func generateEvent(g *protogen.GeneratedFile, message *protogen.Message, config 
 	g.P("// PublishWithUUID will JSON marshal and publish this on a publisher with the given UUID")
 	g.Annotate(message.GoIdent.String()+".PublishWithUUID", message.Location)
 	g.P("func (e *", message.GoIdent, ") PublishWithUUID(ctx ", g.QualifiedGoIdent(contextPkg.Ident("Context")), ", publisher ", g.QualifiedGoIdent(messagePkg.Ident("Publisher")), ", uuid string) error {")
-	g.P("payload, err := ", g.QualifiedGoIdent(protoJSONPkg.Ident("Marshal")), "(x)")
+	g.P("payload, err := ", g.QualifiedGoIdent(protoJSONPkg.Ident("Marshal")), "(e)")
 	g.P("if err != nil {")
 	g.P("return err")
 	g.P("}")

--- a/examples/events_event.pb.go
+++ b/examples/events_event.pb.go
@@ -16,7 +16,7 @@ func (e *NotifyEvent) Publish(ctx context.Context, publisher message.Publisher) 
 
 // PublishWithUUID will JSON marshal and publish this on a publisher with the given UUID
 func (e *NotifyEvent) PublishWithUUID(ctx context.Context, publisher message.Publisher, uuid string) error {
-	payload, err := protojson.Marshal(x)
+	payload, err := protojson.Marshal(e)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (e *CustomTopicEvent) Publish(ctx context.Context, publisher message.Publis
 
 // PublishWithUUID will JSON marshal and publish this on a publisher with the given UUID
 func (e *CustomTopicEvent) PublishWithUUID(ctx context.Context, publisher message.Publisher, uuid string) error {
-	payload, err := protojson.Marshal(x)
+	payload, err := protojson.Marshal(e)
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func (e *AttributeEvent) Publish(ctx context.Context, publisher message.Publishe
 
 // PublishWithUUID will JSON marshal and publish this on a publisher with the given UUID
 func (e *AttributeEvent) PublishWithUUID(ctx context.Context, publisher message.Publisher, uuid string) error {
-	payload, err := protojson.Marshal(x)
+	payload, err := protojson.Marshal(e)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- [X] :bug: event: Use `e` instead of `x` in call to `protojson.Marshal`
- [X] :memo: examples: Update `events` example